### PR TITLE
DM-42153: Only cache the pip cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,11 @@ This is a [composite GitHub Action](https://docs.github.com/en/actions/creating-
 The action:
 
 1. Sets up Python
-2. Installs/updates pip and nox
-3. Caches the nox sessions
+2. Caches the pip cache
+3. Installs/updates pip and nox
 4. Runs nox with the sessions you specify
+
+Unfortunately it is currently unable to cache the nox virtual environments themselves due to a [bug, possibly in nox](https://github.com/wntrblm/nox/issues/735), so the nox virtual environments have to be recreated each time from the local pip cache.
 
 ## Example usage
 
@@ -40,13 +42,10 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           nox-sessions: "typing test"
-          cache-dependency: "**/requirements/*.txt"
 ```
 
 ## Inputs
 
-- `cache-dependency` (string, optional) Glob pattern matching the files that contribute to which dependencies are installed in the nox sessions. This should match either the contributing frozen dependency files or the contributing `pyproject.toml` files. Unfortunately due to limitations in the GitHub Actions syntax only a single glob pattern is supported. Default is `pyproject.toml`.
-- `cache-key-prefix` (string, optional) Prefix for the tox environment cache key. Set to distinguish from other caches. Default is `tox`.
 - `nox-sessions` (string, required) The nox sessions to run, as a space-separated list. Example: `typing test` to run a type checking session and a Python test session.
 - `nox-package` (string, optional) Pip requirement for nox itself (argument to `pip install`). Default is `nox`, without any version constraints.
 - `nox-posargs` (string, optional) Space-separated command line arguments to pass to the nox command. The positional arguments are made available as the `session.posargs` attribute to nox sessions. Default is not to pass any arguments.

--- a/action.yaml
+++ b/action.yaml
@@ -3,20 +3,6 @@ description: >
   This composite action runs nox, and includes setting up Python and caching
   the tox environments.
 inputs:
-  cache-dependency:
-    description: >
-      Glob pattern for the additional dependency files to add to the cache
-      hash. Normally this should reference either frozen dependencies or
-      pyproject.toml files. Due to limitations in the GitHub Actions syntax,
-      only one dependency is supported.
-    required: false
-    default: "pyproject.toml"
-  cache-key-prefix:
-    description: >
-      Prefix for the nox environment cache key. Set to distinguish from
-      other caches.
-    required: false
-    default: "nox"
   nox-sessions:
     description: "Nox sessions to run (a space-delimited list)"
     required: true
@@ -47,19 +33,22 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
 
-    - name: nox install
-      shell: bash
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install --upgrade ${{ inputs.nox-package }}
-
+    # For right now, we cannot cache the nox virtual environments because of
+    # https://github.com/wntrblm/nox/issues/735. Once that bug is fixed, add a
+    # configurable cache prefix and dependency pattern and also cache .nox.
     - name: Cache nox environments
       id: cache-nox
       uses: actions/cache@v3
       if: fromJSON(${{ inputs.use-cache }})
       with:
-        path: .nox
-        key: ${{ inputs.cache-key-prefix }}-${{ inputs.python-version }}-${{ hashFiles('noxfile.py', inputs.cache-dependency) }}
+        path: ~/.cache
+        key: nox-pip-${{ inputs.python-version }}
+
+    - name: nox install
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade ${{ inputs.nox-package }}
 
     - name: Run nox
       shell: bash


### PR DESCRIPTION
Unfortunately, due to https://github.com/wntrblm/nox/issues/735, caching the nox virtual environments causes random intermittant GitHub Actions failures. Until that issue is fixed, only cache the pip cache and remove the settings for a cache prefix and for the dependency glob to decide when to restore the nox virtual environment cache.