### PR TITLE
DM-46034: Fix implementation of use-cache

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -56,7 +56,7 @@ runs:
     - name: Cache nox environments
       id: cache-nox
       uses: actions/cache@v4
-      if: inputs.use-cache == 'true'
+      if: fromJSON(inputs.use-cache) == true
       with:
         path: .nox
         key: ${{ inputs.cache-key-prefix }}|${{ env.pythonLocation }}|${{ hashFiles('noxfile.py', inputs.cache-dependency) }}

--- a/action.yaml
+++ b/action.yaml
@@ -56,7 +56,7 @@ runs:
     - name: Cache nox environments
       id: cache-nox
       uses: actions/cache@v4
-      if: fromJSON(${{ inputs.use-cache }})
+      if: inputs.use-cache == 'true'
       with:
         path: .nox
         key: ${{ inputs.cache-key-prefix }}|${{ env.pythonLocation }}|${{ hashFiles('noxfile.py', inputs.cache-dependency) }}


### PR DESCRIPTION
The way the `fromJSON` trick to force a boolean argument to a boolean was used here appears to have stopped working (or perhaps hadn't worked before?) based on GitHub Actions output for safir and (in the case of run-tox, which has the same construction) Gafaelfawr. Make the construction match what https://github.com/lsst-sqre/build-and-publish-to-pypi does which seems to work better.